### PR TITLE
Rake tasks and Index

### DIFF
--- a/lib/mongoid/lazy_migration.rb
+++ b/lib/mongoid/lazy_migration.rb
@@ -22,6 +22,8 @@ module Mongoid
         include Mongoid::LazyMigration::Document
 
         field :migration_state, :type => Symbol, :default => :pending
+        index({ migration_state: 1 }, { background: true })
+
         after_initialize :ensure_migration, :unless => proc { @migrating }
 
         cattr_accessor :migrate_block, :lock_migration

--- a/lib/mongoid/lazy_migration/railtie/migrate.rake
+++ b/lib/mongoid/lazy_migration/railtie/migrate.rake
@@ -13,7 +13,7 @@ namespace :db do
       Mongoid::LazyMigration.migrate(criteria)
     end
 
-    desc 'Cleanup a migration'
+    desc 'Cleanup a migration - remove migration_state field'
     task :cleanup_migration, [:model] => :environment do |t, args|
       raise "Please provide a model" unless args.model
       Mongoid::LazyMigration.cleanup(eval(args.model))
@@ -25,6 +25,9 @@ namespace :db do
       It can happen that migration block will raise an error, or the process that runs migraiton
       stop, and leave the object in the processing state. To proceed we need to reset that state to pending, so the
       next time the object is loaded it will perform migraion.
+
+      Example:
+        be rake db:mongoid:reset_state[Model,"idididididididid"]
     HEREDOC
     task :reset_state, [:model, :model_id] => :environment do |t, args|
       raise "Please provide a model" unless args.model

--- a/lib/mongoid/lazy_migration/railtie/migrate.rake
+++ b/lib/mongoid/lazy_migration/railtie/migrate.rake
@@ -11,5 +11,12 @@ namespace :db do
       raise "Please provide a model" unless args.model
       Mongoid::LazyMigration.cleanup(eval(args.model))
     end
+
+    desc "Reset the migration_state, requires: Model name and object's id"
+    task :reset_state, [:model, :model_id] => :environment do |t, args|
+      raise "Please provide a model" unless args.model
+      raise "Please provide a object's id" unless args.model_id
+      Mongoid::LazyMigration.reset_state(eval(args.model), args.model_id)
+    end
   end
 end

--- a/lib/mongoid/lazy_migration/railtie/migrate.rake
+++ b/lib/mongoid/lazy_migration/railtie/migrate.rake
@@ -1,6 +1,13 @@
 namespace :db do
   namespace :mongoid do
-    desc 'Migrate the documents specified by criteria. criteria is optional'
+    desc <<-HEREDOC
+      Migrate the documents specified by criteria. criteria is optional
+
+      Simple Example:
+        be rake db:mongoid:lazy_migrate[Model]
+      More advanced example:
+        be rake db:mongoid:lazy_migrate["Model.where(:created_at => '2014-04-01'.to_date..Date.tomorrow)"]
+    HEREDOC
     task :lazy_migrate, [:criteria] => :environment do |t, args|
       criteria = args.criteria ? eval(args.criteria) : nil
       Mongoid::LazyMigration.migrate(criteria)
@@ -12,7 +19,13 @@ namespace :db do
       Mongoid::LazyMigration.cleanup(eval(args.model))
     end
 
-    desc "Reset the migration_state, requires: Model name and object's id"
+    desc <<-HEREDOC
+      Reset object's migration_state to pending, requires: Model name and object's id.
+
+      It can happen that migration block will raise an error, or the process that runs migraiton
+      stop, and leave the object in the processing state. To proceed we need to reset that state to pending, so the
+      next time the object is loaded it will perform migraion.
+    HEREDOC
     task :reset_state, [:model, :model_id] => :environment do |t, args|
       raise "Please provide a model" unless args.model
       raise "Please provide a object's id" unless args.model_id

--- a/lib/mongoid/lazy_migration/tasks.rb
+++ b/lib/mongoid/lazy_migration/tasks.rb
@@ -5,13 +5,12 @@ module Mongoid::LazyMigration::Tasks
     criterias = criteria.nil? ? Mongoid::LazyMigration.models_to_migrate : [criteria]
 
     criterias.each do |criteria|
-      to_migrate = criteria.where(:migration_state.ne => :done).batch_size(50)
+      to_migrate = criteria.where(:migration_state.ne => :done).batch_size(400)
       progress = ProgressBar.new(to_migrate.klass.to_s, to_migrate.count)
       progress.long_running
 
       to_migrate.each_with_index do |o, i|
         progress.inc
-        sleep 0.07 if i % 100 == 0
       end
 
       progress.finish

--- a/lib/mongoid/lazy_migration/tasks.rb
+++ b/lib/mongoid/lazy_migration/tasks.rb
@@ -50,4 +50,11 @@ module Mongoid::LazyMigration::Tasks
         progress.inc
     end
   end
+
+  # It might happened that object is locked with the processing state
+  def reset_state(model, model_id)
+    model.collection.find({'_id' => Moped::BSON::ObjectId.from_string(model_id)}).update({
+      "$set" => {'migration_state' => :pending}
+    })
+  end
 end

--- a/lib/mongoid/lazy_migration/tasks.rb
+++ b/lib/mongoid/lazy_migration/tasks.rb
@@ -1,7 +1,7 @@
 module Mongoid::LazyMigration::Tasks
-  def migrate(criteria=nil)
-    require 'progressbar'
+  require 'progressbar'
 
+  def migrate(criteria=nil)
     criterias = criteria.nil? ? Mongoid::LazyMigration.models_to_migrate : [criteria]
 
     criterias.each do |criteria|
@@ -36,7 +36,7 @@ module Mongoid::LazyMigration::Tasks
     # That's why we don't make a single query that updates all matching fields, although we would have to test it.
     to_cleanup = model.collection.find(selector)
 
-    progress = ProgressBar.new("#{model.class.to_s} cleanup", to_cleanup.count)
+    progress = ProgressBar.new("#{model} cleanup", to_cleanup.count)
     progress.long_running
 
     to_cleanup.

--- a/spec/lazy_migration/document_spec.rb
+++ b/spec/lazy_migration/document_spec.rb
@@ -1,13 +1,7 @@
 require 'spec_helper'
 require 'support/models'
 
-def insert_raw(type, fields={})
-  id = BSON::ObjectId.new
-  type.collection.insert({:_id => id}.merge(fields))
-  id
-end
-
-describe "Mongodb Index" do
+describe "Mongodb index on migration_state" do
   it "has an index on migration_state field" do
     ModelAtomic.collection.indexes.entries.size.should == 0
     ModelAtomic.create_indexes
@@ -15,7 +9,12 @@ describe "Mongodb Index" do
     result.should be_present
   end
 
-  it "doesn't create an index if migration block is not present"
+  it "doesn't create an index if migration block is not present" do
+    ModelNoMigration.collection.indexes.entries.size.should == 0
+    ModelNoMigration.create_indexes
+    result = ModelNoMigration.collection.indexes.entries.select{ |e| e['key'] == {"migration_state" => 1}}.first
+    result.should be_nil
+  end
 end
 
 describe Mongoid::LazyMigration::Document, ".migration(lock)" do

--- a/spec/lazy_migration/document_spec.rb
+++ b/spec/lazy_migration/document_spec.rb
@@ -7,6 +7,17 @@ def insert_raw(type, fields={})
   id
 end
 
+describe "Mongodb Index" do
+  it "has an index on migration_state field" do
+    ModelAtomic.collection.indexes.entries.size.should == 0
+    ModelAtomic.create_indexes
+    result = ModelAtomic.collection.indexes.entries.select{ |e| e['key'] == {"migration_state" => 1}}.first
+    result.should be_present
+  end
+
+  it "doesn't create an index if migration block is not present"
+end
+
 describe Mongoid::LazyMigration::Document, ".migration(lock)" do
   let(:pending)    { insert_raw(ModelLock) }
   let(:processing) { insert_raw(ModelLock, :migration_state => :processing) }

--- a/spec/lazy_migration/tasks_spec.rb
+++ b/spec/lazy_migration/tasks_spec.rb
@@ -47,4 +47,15 @@ describe Mongoid::LazyMigration, ".cleanup" do
   it "chokes if the migration is still defined" do
     proc { Mongoid::LazyMigration.cleanup(ModelAtomic) }.should raise_error
   end
+
+  describe Mongoid::LazyMigration, ".reset_state" do
+    let(:processing_id) { insert_raw(ModelLock, :migration_state => :processing) }
+
+    it "resets state of the object to pending" do
+      Mongoid::LazyMigration.reset_state(ModelLock, processing_id)
+      obj = ModelLock.collection.find({'_id' => Moped::BSON::ObjectId.from_string(processing_id)}).first
+
+      expect(obj['migration_state']).to eq :pending
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,3 +34,9 @@ RSpec.configure do |config|
     Mongoid::IdentityMap.clear
   end
 end
+
+def insert_raw(type, fields={})
+  id = BSON::ObjectId.new
+  type.collection.insert({:_id => id}.merge(fields))
+  id
+end


### PR DESCRIPTION
@amar-shah 

Things that I've changed:
- I added index on migration_sate field.
- I tweaked the rake tasks. (cleanup task is written in moped and it iterates over the objects instead of running one multi query.)

I'm not really convinced that changing cleanup task to iterate over the objects instead 1 multi query is better though. My assumption was that this will prevent from write locks on the collection, but I couldn't really prove, that multi query lock prevents from inserting/updating objects. I will try to investigate that further.