### PR TITLE
mongoid 5 changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
-ENV['MONGOID_VERSION'] ||= '4.0.0'
+ENV['MONGOID_VERSION'] ||= '5.0.0'
 
 group :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,29 +3,28 @@ PATH
   specs:
     mongoid_lazy_migration (0.7.0)
       activesupport
-      mongoid (~> 4.0.0)
+      mongoid (~> 5.0.0)
       progressbar
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.1.4)
-      activesupport (= 4.1.4)
+    activemodel (4.2.5.1)
+      activesupport (= 4.2.5.1)
       builder (~> 3.1)
-    activesupport (4.1.4)
-      i18n (~> 0.6, >= 0.6.9)
+    activesupport (4.2.5.1)
+      i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bond (0.4.3)
-    bson (2.3.0)
+    bson (4.0.1)
     builder (3.2.2)
     coderay (1.0.9)
     columnize (0.3.6)
-    connection_pool (2.0.0)
     debug_inspector (0.0.2)
     debugger (1.6.1)
       columnize (>= 0.3.1)
@@ -34,24 +33,21 @@ GEM
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.2.3)
     diff-lcs (1.2.5)
-    i18n (0.6.11)
+    i18n (0.7.0)
     interception (0.3)
     jist (1.5.1)
       json
-    json (1.8.0)
+    json (1.8.3)
     method_source (0.8.2)
-    minitest (5.4.0)
-    mongoid (4.0.0)
+    minitest (5.8.4)
+    mongo (2.2.2)
+      bson (~> 4.0)
+    mongoid (5.0.2)
       activemodel (~> 4.0)
-      moped (~> 2.0.0)
+      mongo (~> 2.1)
       origin (~> 2.1)
       tzinfo (>= 0.3.37)
-    moped (2.0.0)
-      bson (~> 2.2)
-      connection_pool (~> 2.0)
-      optionable (~> 0.2.0)
-    optionable (0.2.0)
-    origin (2.1.1)
+    origin (2.2.0)
     progressbar (0.21.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
@@ -90,7 +86,7 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
     slop (3.4.6)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     yard (0.8.7)
@@ -99,8 +95,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  mongoid (~> 4.0.0)
+  mongoid (~> 5.0.0)
   mongoid_lazy_migration!
   pry-plus
   rake
   rspec
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongoid_lazy_migration (0.7.0)
+    mongoid_lazy_migration (0.8.0)
       activesupport
       mongoid (~> 5.0.0)
       progressbar

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 Mongoid Lazy Migration
 ======================
 
-## (Temporary) This is a forked version, that aims to support only Mongoid in ver 4.0.0 +
-
-### If you use Mongoid in version 3.1.6 check the git tags.
-
-
-[![Build Status](https://secure.travis-ci.org/nviennot/mongoid_lazy_migration.png?branch=master)](http://travis-ci.org/nviennot/mongoid_lazy_migration)
-
 LazyMigration allows you to migrate a Mongoid collection on the fly. As
 instances of your model are initialized, the migration is run. In the
 background, workers can traverse the collection and migrate other documents.
@@ -241,7 +234,8 @@ A couple of points that you need to be aware of:
 Compatibility
 -------------
 
-This version of LazyMigration is tested against MRI 2.0.0p247
+Mongoid 5.0.0+
+This version of LazyMigration is tested against MRI ruby 2.2.3p173
 
 License
 -------

--- a/lib/mongoid/lazy_migration.rb
+++ b/lib/mongoid/lazy_migration.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/concern'
 require 'active_support/core_ext'
 require 'set'

--- a/lib/mongoid/lazy_migration/document.rb
+++ b/lib/mongoid/lazy_migration/document.rb
@@ -62,8 +62,12 @@ module Mongoid::LazyMigration::Document
 
     selector = atomic_selector.merge('migration_state' => { "$in" => [nil, 'pending'] })
     changes  = { "$set" => { 'migration_state' => 'processing' }}
-    safety   = { :safe => true }
-    self.class.with(safety).where(selector).update(changes).successful?
+
+    view = self.class.criteria.view
+    cmd = { :findandmodify => collection.name, :query => selector, update: changes, bypassDocumentValidation: false }
+    result = view.database.command(cmd)
+
+    (doc = result.documents.first) && doc[:lastErrorObject] && doc[:lastErrorObject]["updatedExisting"]
   end
 
   def wait_for_completion

--- a/lib/mongoid/lazy_migration/document.rb
+++ b/lib/mongoid/lazy_migration/document.rb
@@ -63,8 +63,7 @@ module Mongoid::LazyMigration::Document
     selector = atomic_selector.merge('migration_state' => { "$in" => [nil, 'pending'] })
     changes  = { "$set" => { 'migration_state' => 'processing' }}
     safety   = { :safe => true }
-
-    self.class.with(safety).where(selector).query.update(changes)['updatedExisting']
+    self.class.with(safety).where(selector).update(changes).successful?
   end
 
   def wait_for_completion

--- a/lib/mongoid/lazy_migration/tasks.rb
+++ b/lib/mongoid/lazy_migration/tasks.rb
@@ -35,8 +35,7 @@ module Mongoid::LazyMigration::Tasks
     selector = { :migration_state => { "$exists" => true }}
     changes  = {"$unset" => { :migration_state => 1}}
     safety   = { :safe => true, :multi => true }
-    multi    = { :multi => true }
 
-    model.with(safety).where(selector).query.update(changes, multi)
+    model.with(safety).where(selector).update_all(changes)
   end
 end

--- a/lib/mongoid/lazy_migration/tasks.rb
+++ b/lib/mongoid/lazy_migration/tasks.rb
@@ -34,8 +34,7 @@ module Mongoid::LazyMigration::Tasks
 
     selector = { :migration_state => { "$exists" => true }}
     changes  = {"$unset" => { :migration_state => 1}}
-    safety   = { :safe => true, :multi => true }
 
-    model.with(safety).where(selector).update_all(changes)
+    model.where(selector).update_all(changes)
   end
 end

--- a/lib/mongoid/lazy_migration/version.rb
+++ b/lib/mongoid/lazy_migration/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module LazyMigration
-    VERSION = "0.7.0"
+    VERSION = "0.8.0"
   end
 end

--- a/mongoid_lazy_migration.gemspec
+++ b/mongoid_lazy_migration.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "Mongoid lazy migration toolkit"
   s.description = "Migrate your documents lazily in atomic, or locked fashion to avoid downtime"
 
-  s.add_dependency("mongoid", "~> 4.0.0")
+  s.add_dependency("mongoid", "~> 5.0.0")
   s.add_dependency("activesupport")
   s.add_dependency("progressbar")
 

--- a/spec/lazy_migration/document_spec.rb
+++ b/spec/lazy_migration/document_spec.rb
@@ -3,7 +3,7 @@ require 'support/models'
 
 def insert_raw(type, fields={})
   id = BSON::ObjectId.new
-  type.collection.insert({:_id => id}.merge(fields))
+  type.collection.insert_one({:_id => id}.merge(fields))
   id
 end
 

--- a/spec/lazy_migration/tasks_spec.rb
+++ b/spec/lazy_migration/tasks_spec.rb
@@ -3,8 +3,8 @@ require 'support/models'
 require 'support/mute_progressbar'
 
 describe Mongoid::LazyMigration, ".migrate" do
-  let!(:pendings_lock)   { 5.times { ModelLock.collection.insert({})} }
-  let!(:pendings_atomic) { 5.times { ModelAtomic.collection.insert({})} }
+  let!(:pendings_lock)   { 5.times { ModelLock.collection.insert_one({})} }
+  let!(:pendings_atomic) { 5.times { ModelAtomic.collection.insert_one({})} }
 
   it "migrates all the models by default" do
     ModelLock.where(:migrated => true).count.should == 0
@@ -30,8 +30,8 @@ describe Mongoid::LazyMigration, ".migrate" do
 end
 
 describe Mongoid::LazyMigration, ".cleanup" do
-  let!(:done1) { ModelNoMigration.collection.insert(:migration_state => :done) }
-  let!(:done2) { ModelNoMigration.collection.insert(:migration_state => :done) }
+  let!(:done1) { ModelNoMigration.collection.insert_one(:migration_state => :done) }
+  let!(:done2) { ModelNoMigration.collection.insert_one(:migration_state => :done) }
 
   it "cleans up all the documents of a specific class" do
     Mongoid::LazyMigration.cleanup(ModelNoMigration)
@@ -39,7 +39,7 @@ describe Mongoid::LazyMigration, ".cleanup" do
   end
 
   it "chokes if any documents are still being processed" do
-    ModelNoMigration.collection.insert(:migration_state => :processing)
+    ModelNoMigration.collection.insert_one(:migration_state => :processing)
     proc { Mongoid::LazyMigration.cleanup(ModelNoMigration) }.should raise_error
     ModelNoMigration.where(:migration_state => nil).count.should == 0
   end


### PR DESCRIPTION
@sparrovv @tomekn @pvdb @amar-shah @lukaso please take a look.
@sparrovv you did last upgrade so might know more
This gem wasn't 100% compatible with mongoid5,
Mainly because Mongoid now used Mongo ruby driver and not Moped.

Since updating to mongo5 the version of this gem has been downgraded in chopin from 0.7 to 0.6 because 0.7 used mongoid ~> 4.0.0 (which means any 4, but not 5), and 0.6 uses mongoid  >=3 :smile: 

Locked migrations do not work in previous version, giving an error:
```
NoMethodError:
       undefined method `query' for #<Mongoid::Criteria:0x007fb427c67978>
```