### PR TITLE
Attribute missing :migration_state

### DIFF
--- a/lib/mongoid/lazy_migration.rb
+++ b/lib/mongoid/lazy_migration.rb
@@ -20,7 +20,7 @@ module Mongoid
         include Mongoid::LazyMigration::Document
 
         field :migration_state, :type => Symbol, :default => :pending
-        after_initialize :ensure_migration, :unless => proc { @migrating }
+        after_initialize :ensure_migration, :unless => proc { @migrating || attribute_missing?(:migration_state) }
 
         cattr_accessor :migrate_block, :lock_migration
         self.migrate_block = block

--- a/lib/mongoid/lazy_migration.rb
+++ b/lib/mongoid/lazy_migration.rb
@@ -20,7 +20,7 @@ module Mongoid
         include Mongoid::LazyMigration::Document
 
         field :migration_state, :type => Symbol, :default => :pending
-        after_initialize :ensure_migration, :unless => proc { @migrating || attribute_missing?(:migration_state) }
+        after_initialize :ensure_migration, :unless => proc { @migrating || readonly? }
 
         cattr_accessor :migrate_block, :lock_migration
         self.migrate_block = block

--- a/mongoid_lazy_migration.gemspec
+++ b/mongoid_lazy_migration.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "Mongoid lazy migration toolkit"
   s.description = "Migrate your documents lazily in atomic, or locked fashion to avoid downtime"
 
-  s.add_dependency("mongoid", "~> 5.0.0")
+  s.add_dependency("mongoid", "5.0.1")
   s.add_dependency("activesupport")
   s.add_dependency("progressbar")
 

--- a/spec/lazy_migration/document_spec.rb
+++ b/spec/lazy_migration/document_spec.rb
@@ -20,8 +20,13 @@ describe Mongoid::LazyMigration::Document, ".migration(lock)" do
     ModelLock.find(done).migrated.should_not == true
   end
 
-  it "doesn't migrate pending models that use a projection" do
-    ModelLock.only(:migrated).find(pending).migrated.should_not == true
+  context "readonly documents" do
+    # a projection will turn an object into a readonly object
+    # see mongoid/lib/mongoid/stateful.rb
+    it "doesn't migrate pending models that are readonly" do
+      ModelLock.only(:migrated).find(pending).migrated.should_not == true
+      ModelLock.only(:migration_state).find(pending).migration_state.should == :pending
+    end
   end
 
   it "doesn't update the updated_at field during the migration" do
@@ -58,6 +63,13 @@ describe Mongoid::LazyMigration::Document, ".migration(atomic)" do
 
   it "doesn't migrate pending models that use a projection" do
     ModelAtomic.only(:migrated).find(pending).migrated.should_not == true
+  end
+
+  context "readonly documents" do
+    it "doesn't migrate pending models that are readonly" do
+      ModelAtomic.only(:migrated).find(pending).migrated.should_not == true
+      ModelAtomic.only(:migration_state).find(pending).migration_state.should == :pending
+    end
   end
 
   # I don't know how to test this. Please help.

--- a/spec/lazy_migration/document_spec.rb
+++ b/spec/lazy_migration/document_spec.rb
@@ -61,10 +61,6 @@ describe Mongoid::LazyMigration::Document, ".migration(atomic)" do
     ModelAtomic.find(done).migrated.should_not == true
   end
 
-  it "doesn't migrate pending models that use a projection" do
-    ModelAtomic.only(:migrated).find(pending).migrated.should_not == true
-  end
-
   context "readonly documents" do
     it "doesn't migrate pending models that are readonly" do
       ModelAtomic.only(:migrated).find(pending).migrated.should_not == true

--- a/spec/lazy_migration/document_spec.rb
+++ b/spec/lazy_migration/document_spec.rb
@@ -20,6 +20,10 @@ describe Mongoid::LazyMigration::Document, ".migration(lock)" do
     ModelLock.find(done).migrated.should_not == true
   end
 
+  it "doesn't migrate pending models that use a projection" do
+    ModelLock.only(:migrated).find(pending).migrated.should_not == true
+  end
+
   it "doesn't update the updated_at field during the migration" do
     model = ModelLock.find(pending)
     model.updated_at.should == nil
@@ -50,6 +54,10 @@ describe Mongoid::LazyMigration::Document, ".migration(atomic)" do
 
   it "doesn't migrate done models on fetch" do
     ModelAtomic.find(done).migrated.should_not == true
+  end
+
+  it "doesn't migrate pending models that use a projection" do
+    ModelAtomic.only(:migrated).find(pending).migrated.should_not == true
   end
 
   # I don't know how to test this. Please help.


### PR DESCRIPTION
When running a projection without `:migration_state` on a collection that has a migration code on it, it will result in an error
```ruby
class Test
  migration do
    #...
  end
end
Test.only(:abc).first #==>> Missing attribute: 'migration_state'.
```

There is no need to make a special case and to include `:migration_state` as well because the migration won't do anything anyway because the object is `readonly` so it will not save. If attempting a manual save it will result in an error.
```ruby
Test.only(:migration_state).first.readonly? #==>> true

Test.only(:migration_state).first.save
#Mongoid::Errors::ReadonlyDocument:
#message:
#  Attempted to persist the readonly document 'Rfq'.
#summary:
#  Documents loaded from the database using #only cannot be persisted.
#resolution:
#  Don't attempt to persist documents that are flagged as readonly.
```

#### So the **solution** is to skip migration if an object is `readonly`