### PR TITLE
upgrade versioning logic for dependabot

### DIFF
--- a/lib/mongoid/lazy_migration/version.rb
+++ b/lib/mongoid/lazy_migration/version.rb
@@ -1,5 +1,8 @@
 module Mongoid
   module LazyMigration
-    VERSION = "0.8.1"
+    base = "0.8.1"
+
+  # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
+    VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"
   end
 end

--- a/lib/mongoid/lazy_migration/version.rb
+++ b/lib/mongoid/lazy_migration/version.rb
@@ -1,6 +1,6 @@
 module Mongoid
   module LazyMigration
-    base = "0.8.1"
+    base = "0.8.2"
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
     VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/mongoid_lazy_migration.gemspec
+++ b/mongoid_lazy_migration.gemspec
@@ -2,15 +2,9 @@
 $:.unshift File.expand_path("../lib", __FILE__)
 
 require 'mongoid/lazy_migration/version'
-gem_version = if ENV['GEM_PRE_RELEASE'].nil? || ENV['GEM_PRE_RELEASE'].empty?
-                Mongoid::LazyMigration::VERSION
-              else
-                "#{Mongoid::LazyMigration::VERSION}.#{ENV['GEM_PRE_RELEASE']}"
-              end
-
 Gem::Specification.new do |s|
   s.name        = "mongoid_lazy_migration"
-  s.version     = gem_version
+  s.version     = Mongoid::LazyMigration::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Nicolas Viennot"]
   s.email       = ["nicolas@viennot.biz"]


### PR DESCRIPTION
upgrade gemstash versioning logic so that dependabot can automatically
manage versions of dependencies in the gemspec

dependabot is used to create automatic PRs for security vulnerabilities